### PR TITLE
Added slicing operator support.

### DIFF
--- a/core/interpreter.py
+++ b/core/interpreter.py
@@ -516,6 +516,32 @@ class Interpreter:
         if should_return_null: return res.success(Number.null)
         return res.success(elements)
 
+    def visit_IndexGetNode(self, node, context):
+        res = RTResult()
+        indexee = res.register(self.visit(node.indexee, context))
+        if res.should_return(): return res
+
+        index_start = res.register(self.visit(node.index_start, context))
+        if res.should_return(): return res
+
+        if node.index_end != None:
+            index_end = res.register(self.visit(node.index_end, context))
+            if res.should_return(): return res
+
+        if node.index_step != None:
+            index_step = res.register(self.visit(node.index_step, context))
+            if res.should_return(): return res
+
+        if node.index_end != None and node.index_step != None:
+            result, error = indexee.get_index(index_start, index_end, index_step)
+        elif node.index_end != None:
+            result, error = indexee.get_index(index_start, index_end)
+        else:
+            result, error = indexee.get_index(index_start)
+
+        if error: return res.failure(error)
+        return res.success(result)
+
     def visit_ClassNode(self, node, context):
         res = RTResult()
 

--- a/core/nodes.py
+++ b/core/nodes.py
@@ -246,6 +246,18 @@ class ForInNode:
 
         self.child = None
 
+
+class IndexGetNode:
+    def __init__(self, pos_start, pos_end, indexee, index_start, index_end = None, index_step = None):
+        self.pos_start = pos_start
+        self.pos_end = pos_end
+        self.indexee = indexee
+        self.index_start = index_start
+        self.index_end = index_end
+        self.index_step = index_step
+
+        self.child = None
+
 class ClassNode:
     def __init__(self, class_name_tok, body_nodes, pos_start, pos_end):
         self.class_name_tok = class_name_tok

--- a/examples/slicing.rn
+++ b/examples/slicing.rn
@@ -1,0 +1,36 @@
+# Slicing
+
+# Array of Numbers slicing
+var my_arr = [1,2,3,4,5,6,7,8,9,0]
+print(my_arr[0])
+print(my_arr[0:5])
+print(my_arr[0:9:2])
+# print(my_arr[])
+# print(my_arr[-1])
+
+# Array of Strings slicing
+var my_str_arr = ["This", "is", "an", "example", "string"]
+print(my_str_arr[0])
+print(my_str_arr[0:3])
+print(my_str_arr[0:5:2])
+# print(my_str_arr[])
+
+# Complex Array slicing
+var my_complex_arr = [1, "This", 2, "is", 3, "an", 4, "example", 5, "string", 4.64, 2.4556, 324.2345]
+print(my_complex_arr[0])
+print(my_complex_arr[11])
+print(my_complex_arr[0:9:1])
+print(my_complex_arr[0:10:2])
+# print(my_complex_arr[])
+
+# String slicing
+var my_str = "This is an example string"
+
+print(my_str[0:4:1])
+print(my_str[5:7])
+print(my_str[9])
+# print(my_str[])
+
+# Straight forward slicing
+print("string"[0:3])
+print([1,2,3,4,5,6,7,8,9,0][0:5])


### PR DESCRIPTION
Radon is now able to slice data-types easily with this syntax. `data[start:end:step]`

Examples:

```radon
# Slicing

# Array of Numbers slicing
var my_arr = [1,2,3,4,5,6,7,8,9,0]
print(my_arr[0])
print(my_arr[0:5])
print(my_arr[0:9:2])
# print(my_arr[])
# print(my_arr[-1])

# Array of Strings slicing
var my_str_arr = ["This", "is", "an", "example", "string"]
print(my_str_arr[0])
print(my_str_arr[0:3])
print(my_str_arr[0:5:2])
# print(my_str_arr[])

# Complex Array slicing
var my_complex_arr = [1, "This", 2, "is", 3, "an", 4, "example", 5, "string", 4.64, 2.4556, 324.2345]
print(my_complex_arr[0])
print(my_complex_arr[11])
print(my_complex_arr[0:9:1])
print(my_complex_arr[0:10:2])
# print(my_complex_arr[])

# String slicing
var my_str = "This is an example string"

print(my_str[0:4:1])
print(my_str[5:7])
print(my_str[9])
# print(my_str[])

# Straight forward slicing
print("string"[0:3])
print([1,2,3,4,5,6,7,8,9,0][0:5])
```