### PR TITLE
Added `help` function support for modules

### DIFF
--- a/core/datatypes.py
+++ b/core/datatypes.py
@@ -1455,6 +1455,20 @@ class Module(Value):
     file_path: str
     symbol_table: SymbolTable
 
+    def __help_repr__(self) -> str:
+        result: str = f"Help on object {self.name}:\n\nmodule {self.name}\n|\n"
+        for k in self.symbol_table.symbols:
+            f = self.symbol_table.symbols[k]
+
+            if (type(f).__name__ == "BuiltInClass") or (type(f).__name__ == "BuiltInFunction"): continue
+            if k == "null" or k == "false" or k == "true": continue
+                
+            if isinstance(f,Function):
+                result += f.__help_repr_method__()
+            elif isinstance(f, Value):
+                result += f"| {k} = {f!r}\n|\n"
+        return result
+
     def __init__(self, name: str, file_path: str, symbol_table: SymbolTable) -> None:
         super().__init__()
         self.name = name

--- a/core/datatypes.py
+++ b/core/datatypes.py
@@ -1460,10 +1460,12 @@ class Module(Value):
         for k in self.symbol_table.symbols:
             f = self.symbol_table.symbols[k]
 
-            if (type(f).__name__ == "BuiltInClass") or (type(f).__name__ == "BuiltInFunction"): continue
-            if k == "null" or k == "false" or k == "true": continue
-                
-            if isinstance(f,Function):
+            if (type(f).__name__ == "BuiltInClass") or (type(f).__name__ == "BuiltInFunction"):
+                continue
+            if k == "null" or k == "false" or k == "true":
+                continue
+
+            if isinstance(f, Function):
                 result += f.__help_repr_method__()
             elif isinstance(f, Value):
                 result += f"| {k} = {f!r}\n|\n"


### PR DESCRIPTION
Closes #164 

This adds support for printing module contents by the `help(obj)` function

But, I'm not sure about these lines in the code:
```
if (type(f).__name__ == "BuiltInClass") or (type(f).__name__ == "BuiltInFunction"): continue
if k == "null" or k == "false" or k == "true": continue
```