### PR TITLE
Add encapsulation enforcement and abstract classes (closes #212, #210, #211)

### DIFF
--- a/core/datatypes.py
+++ b/core/datatypes.py
@@ -1111,12 +1111,16 @@ class BaseFunction(Value):
     arg_names: list[str]
     va_name: Optional[str]
     va_kw_name: Optional[str]
+    access_modifier: str
+    is_abstract: bool
 
     def __init__(self, name: Optional[str], symbol_table: Optional[SymbolTable]) -> None:
         super().__init__()
         self.name = name if name is not None else "<anonymous>"
         self.symbol_table = symbol_table
         self.owner_class = None
+        self.access_modifier = "public"
+        self.is_abstract = False
 
     def generate_new_context(self) -> Context:
         new_context = Context(self.name, self.context, self.pos_start)
@@ -1438,12 +1442,14 @@ class BaseClass(Value, ABC):
     name: str
     desc: Optional[str]
     symbol_table: SymbolTable
+    is_abstract: bool
 
     def __init__(self, name: str, desc: Optional[str], symbol_table: SymbolTable) -> None:
         super().__init__()
         self.name = name
         self.desc = desc
         self.symbol_table = symbol_table
+        self.is_abstract = False
 
     @abstractmethod
     def get(self, name: str) -> Optional[Value]: ...
@@ -1466,6 +1472,11 @@ class BaseClass(Value, ABC):
 
     def execute(self, args: list[Value], kwargs: dict[str, Value]) -> RTResult[Value]:
         res = RTResult[Value]()
+
+        if self.is_abstract:
+            return res.failure(
+                RTError(self.pos_start, self.pos_end, f"Cannot instantiate abstract class '{self.name}'", self.context)
+            )
 
         inst = res.register(self.create(args))
         if res.should_return():
@@ -1594,7 +1605,7 @@ class Class(BaseClass):
 
 
 class Function(BaseFunction):
-    body_node: Node
+    body_node: Optional[Node]
     arg_names: list[str]
     defaults: list[Optional[Value]]
     should_auto_return: bool
@@ -1624,7 +1635,7 @@ class Function(BaseFunction):
         self,
         name: Optional[str],
         symbol_table: Optional[SymbolTable],
-        body_node: Node,
+        body_node: Optional[Node],
         arg_names: list[str],
         defaults: list[Optional[Value]],
         should_auto_return: bool,
@@ -1647,8 +1658,21 @@ class Function(BaseFunction):
         from core.interpreter import Interpreter  # Lazy import
 
         res = RTResult[Value]()
+
+        if self.body_node is None:
+            return res.failure(
+                RTError(
+                    self.pos_start,
+                    self.pos_end,
+                    f"Method '{self.name}' is abstract and has no implementation",
+                    self.context,
+                )
+            )
+
         interpreter = Interpreter()
         exec_ctx = self.generate_new_context()
+        if self.owner_class is not None:
+            exec_ctx.symbol_table.set("__class__", self.owner_class)
 
         res.register(
             self.check_and_populate_args(self.arg_names, args, kwargs, self.defaults, self.max_pos_args, exec_ctx)
@@ -1682,6 +1706,8 @@ class Function(BaseFunction):
             self.max_pos_args,
         )
         copy.owner_class = self.owner_class
+        copy.access_modifier = self.access_modifier
+        copy.is_abstract = self.is_abstract
         copy.set_context(self.context)
         copy.set_pos(self.pos_start, self.pos_end)
         return copy

--- a/core/interpreter.py
+++ b/core/interpreter.py
@@ -183,6 +183,49 @@ class Interpreter:
 
         return res.success(merged)
 
+    def _get_current_class(self, context: Context) -> Optional[Class]:
+        # Walk the (stable, lexically-scoped) symbol table chain rather than
+        # Context.parent -- a Function's `.context` gets rebound to the call
+        # site every time it crosses a call/attribute-access boundary (see
+        # call_value and visit_AttrAccessNode), which would lose the class a
+        # closure was defined in. `.symbol_table` is set once at definition
+        # time and never reassigned, so it reliably threads through closures.
+        value = context.symbol_table.get("__class__")
+        if isinstance(value, Class):
+            return value
+        return None
+
+    def _check_member_access(
+        self, attr_value: Value, attr_name: str, context: Context, pos_start: Position, pos_end: Position
+    ) -> Optional[RTError]:
+        if not isinstance(attr_value, Function) or attr_value.access_modifier == "public":
+            return None
+
+        owner = attr_value.owner_class
+        if owner is None:
+            return None
+
+        caller_class = self._get_current_class(context)
+        if attr_value.access_modifier == "private":
+            allowed = caller_class is owner
+        else:  # protected -- visible to the whole ancestor/descendant chain,
+            # in both directions: a subclass reaching an inherited protected
+            # member (owner in caller_class.mro), and base-class code that
+            # virtually dispatches into a subclass's protected override
+            # (caller_class in owner.mro), as in the Template Method pattern.
+            allowed = caller_class is not None and (owner in caller_class.mro or caller_class in owner.mro)
+
+        if allowed:
+            return None
+
+        return RTError(
+            pos_start,
+            pos_end,
+            f"Cannot access {attr_value.access_modifier} member '{attr_name}' of class '{owner.name}' "
+            "from outside its class hierarchy",
+            context,
+        )
+
     def _compute_parent_mro(self, parents: list[Class], node: ClassNode, context: Context) -> RTResult[list[Class]]:
         res = RTResult[list[Class]]()
         sequences = [parent.mro[:] for parent in parents]
@@ -727,6 +770,8 @@ class Interpreter:
             .set_context(context)
             .set_pos(node.pos_start, node.pos_end)
         )
+        func_value.access_modifier = node.access_modifier
+        func_value.is_abstract = node.is_abstract
 
         if node.var_name_tok:
             assert context.symbol_table is not None
@@ -1052,10 +1097,33 @@ class Interpreter:
             .set_pos(node.pos_start, node.pos_end)
         )
         cls.mro = [cls, *parent_mro]
+        cls.is_abstract = node.is_abstract
 
         for value in cls.own_symbol_table.symbols.values():
             if isinstance(value, Function):
                 value.owner_class = cls
+
+        if not node.is_abstract:
+            abstract_names: set[str] = set()
+            for ancestor in cls.mro:
+                for name, value in ancestor.own_symbol_table.symbols.items():
+                    if isinstance(value, Function) and value.is_abstract:
+                        abstract_names.add(name)
+
+            def is_still_abstract(name: str) -> bool:
+                resolved = merged_symbol_table.symbols.get(name)
+                return not isinstance(resolved, Function) or resolved.is_abstract
+
+            unimplemented = sorted(name for name in abstract_names if is_still_abstract(name))
+            if unimplemented:
+                return res.failure(
+                    RTError(
+                        node.pos_start,
+                        node.pos_end,
+                        f"Class '{class_name}' must implement abstract method(s): {', '.join(unimplemented)}",
+                        context,
+                    )
+                )
 
         context.symbol_table.set(class_name, cls)
         return res.success(cls)
@@ -1217,6 +1285,10 @@ class Interpreter:
                 return res.failure(
                     RTError(node.pos_start, node.pos_end, f"Attribute '{attr_name}' does not exist", context)
                 )
+
+            access_error = self._check_member_access(attr_value, attr_name, context, node.pos_start, node.pos_end)
+            if access_error is not None:
+                return res.failure(access_error)
 
             if isinstance(orig_value, BaseInstance) and isinstance(attr_value, BaseFunction):
                 attr_value = res.register(orig_value.bind_method(attr_value))

--- a/core/nodes.py
+++ b/core/nodes.py
@@ -254,7 +254,7 @@ class FuncDefNode:
     var_name_tok: Optional[Token]
     arg_name_toks: list[Token]
     defaults: list[Optional[Node]]
-    body_node: Node
+    body_node: Optional[Node]
     should_auto_return: bool
     static: bool
     desc: str
@@ -264,6 +264,9 @@ class FuncDefNode:
 
     pos_start: Position
     pos_end: Position
+
+    access_modifier: str = "public"
+    is_abstract: bool = False
 
 
 class CallNode:
@@ -403,6 +406,8 @@ class ClassNode:
 
     pos_start: Position
     pos_end: Position
+
+    is_abstract: bool = False
 
 
 @dataclass

--- a/core/parser.py
+++ b/core/parser.py
@@ -951,7 +951,11 @@ class Parser:
             assert func_def is not None
             node = func_def
 
-        elif tok.matches(TT_KEYWORD, "class"):
+        elif tok.matches(TT_KEYWORD, "class") or (
+            tok.matches(TT_KEYWORD, "abstract")
+            and self.tok_idx + 1 < len(self.tokens)
+            and self.tokens[self.tok_idx + 1].matches(TT_KEYWORD, "class")
+        ):
             self.in_class += 1
             class_node = res.register(self.class_node())
             self.in_class -= 1
@@ -1415,6 +1419,11 @@ class Parser:
 
         pos_start = self.current_tok.pos_start
 
+        is_abstract = False
+        if self.current_tok.matches(TT_KEYWORD, "abstract"):
+            is_abstract = True
+            self.advance(res)
+
         if not self.current_tok.matches(TT_KEYWORD, "class"):
             assert False, "unreachable"
 
@@ -1481,7 +1490,11 @@ class Parser:
 
         self.advance(res)
 
-        return res.success(ClassNode(class_name_tok, parent_nodes, desc, body, pos_start, self.current_tok.pos_end))
+        return res.success(
+            ClassNode(
+                class_name_tok, parent_nodes, desc, body, pos_start, self.current_tok.pos_end, is_abstract=is_abstract
+            )
+        )
 
     def func_def(self) -> ParseResult[Node]:
         res = ParseResult[Node]()
@@ -1489,6 +1502,7 @@ class Parser:
         node_pos_start = self.current_tok.pos_start
 
         static = False
+        access_modifier = "public"
         while self.current_tok.type == TT_KEYWORD and self.current_tok.value in (
             "static",
             "public",
@@ -1497,6 +1511,9 @@ class Parser:
         ):
             if self.current_tok.value == "static":
                 static = True
+            else:
+                assert isinstance(self.current_tok.value, str)
+                access_modifier = self.current_tok.value
             self.advance(res)
 
         if not self.current_tok.matches(TT_KEYWORD, "fun"):
@@ -1656,11 +1673,37 @@ class Parser:
                     max_pos_args=max_pos_args,
                     pos_start=node_pos_start,
                     pos_end=self.current_tok.pos_end,
+                    access_modifier=access_modifier,
                 )
             )
 
+        # Look ahead past newlines for a '{' (allows the brace on its own line). If no
+        # block body or arrow body is found, this is an abstract method declaration with
+        # no implementation -- only valid directly inside a class body. Newlines are
+        # un-consumed in that case so `statements()` still sees the statement separator.
+        saved_idx = self.tok_idx
         self.skip_newlines()
         if self.current_tok.type != TT_LBRACE:
+            if self.in_class:
+                self.reverse(self.tok_idx - saved_idx)
+                return res.success(
+                    FuncDefNode(
+                        var_name_tok,
+                        arg_name_toks,
+                        defaults,
+                        None,
+                        False,
+                        static=static,
+                        desc="[No Description]",
+                        va_name=va_name,
+                        va_kw_name=va_kw_name,
+                        max_pos_args=max_pos_args,
+                        pos_start=node_pos_start,
+                        pos_end=self.current_tok.pos_end,
+                        access_modifier=access_modifier,
+                        is_abstract=True,
+                    )
+                )
             return res.failure(
                 RNSyntaxError(self.current_tok.pos_start, self.current_tok.pos_end, "Expected '->' or '{'")
             )
@@ -1698,6 +1741,7 @@ class Parser:
                 max_pos_args=max_pos_args,
                 pos_start=node_pos_start,
                 pos_end=self.current_tok.pos_end,
+                access_modifier=access_modifier,
             )
         )
 

--- a/core/tokens.py
+++ b/core/tokens.py
@@ -140,6 +140,7 @@ KEYWORDS = [
     "public",
     "private",
     "protected",
+    "abstract",
 ]
 
 TokenValue: TypeAlias = Optional[str | int | float]

--- a/tests/lang/abstract_classes.rn
+++ b/tests/lang/abstract_classes.rn
@@ -1,0 +1,128 @@
+# Abstraction (#210, #211): `abstract class` cannot be instantiated directly,
+# and a concrete subclass must implement every abstract method it inherits.
+
+abstract class Shape {
+    fun area()
+    fun perimeter()
+
+    fun describe() -> "a shape with area " + str(this.area())
+}
+
+class Circle(Shape) {
+    fun __constructor__(radius) {
+        this.radius = radius
+    }
+
+    fun area() -> this.radius * this.radius * 3
+    fun perimeter() -> this.radius * 2 * 3
+}
+
+var circle = Circle(2)
+assert circle.area() == 12
+assert circle.perimeter() == 12
+assert circle.describe() == "a shape with area 12"
+
+# Instantiating the abstract class itself is a runtime error.
+try {
+    Shape()
+    assert false, "expected instantiating an abstract class to fail"
+} catch as e {
+    assert e == "Cannot instantiate abstract class 'Shape'"
+}
+
+# A subclass that doesn't implement every abstract method is rejected at
+# class-definition time, before it's ever instantiated.
+try {
+    class Broken(Shape) {
+        fun area() -> 0
+        # perimeter() is still missing
+    }
+    assert false, "expected class definition to fail for a missing override"
+} catch as e {
+    assert e == "Class 'Broken' must implement abstract method(s): perimeter"
+}
+
+# Multi-level: an abstract subclass doesn't need to implement its parent's
+# abstract methods; only the first concrete class in the chain does.
+abstract class Named {
+    fun name()
+}
+
+abstract class NamedShape(Named) {
+    fun area()
+}
+
+class Square(NamedShape) {
+    fun __constructor__(side) {
+        this.side = side
+    }
+
+    fun name() -> "square"
+    fun area() -> this.side * this.side
+}
+
+var square = Square(4)
+assert square.name() == "square"
+assert square.area() == 16
+
+try {
+    Named()
+    assert false, "expected instantiating an abstract class to fail"
+} catch as e {
+    assert e == "Cannot instantiate abstract class 'Named'"
+}
+try {
+    NamedShape()
+    assert false, "expected instantiating an abstract class to fail"
+} catch as e {
+    assert e == "Cannot instantiate abstract class 'NamedShape'"
+}
+
+# Abstract classes can mix concrete methods, static methods, and access
+# modifiers with abstract method declarations.
+abstract class Repository {
+    private fun log(msg) -> "[log] " + msg
+
+    static fun kind() -> "repository"
+
+    protected fun save(item)
+    public fun save_and_log(item) -> this.log(this.save(item))
+}
+
+class ListRepository(Repository) {
+    fun __constructor__() {
+        this.items = []
+    }
+
+    protected fun save(item) -> "saved " + item
+}
+
+assert Repository.kind() == "repository"
+var repo = ListRepository()
+assert repo.save_and_log("widget") == "[log] saved widget"
+
+# A concrete class further down the chain can be reused as a base for
+# another abstract class, and abstract-ness always tracks the `abstract`
+# keyword on that specific class, not inherited implicitly from ancestors.
+class ConcreteBase {
+    fun greet() -> "hi"
+}
+
+abstract class StillAbstract(ConcreteBase) {
+    fun extra()
+}
+
+try {
+    StillAbstract()
+    assert false, "expected instantiating an abstract class to fail"
+} catch as e {
+    assert e == "Cannot instantiate abstract class 'StillAbstract'"
+}
+
+class Finisher(StillAbstract) {
+    fun extra() -> "extra"
+}
+
+var finisher = Finisher()
+assert finisher.greet() == "hi"
+assert finisher.extra() == "extra"

--- a/tests/lang/abstract_classes.rn.json
+++ b/tests/lang/abstract_classes.rn.json
@@ -1,0 +1,1 @@
+{"code": 0, "stdout": "", "stderr": ""}

--- a/tests/lang/access_modifiers.rn
+++ b/tests/lang/access_modifiers.rn
@@ -35,13 +35,41 @@ class VisibilityMixed {
 var basics = VisibilityBasics(10)
 assert basics.implicit_method() == 10
 assert basics.public_method() == 11
-assert basics.private_method() == 12
-assert basics.protected_method() == 13
+
+# private/protected members are enforced: calling them from outside the
+# declaring class's hierarchy (e.g. top-level script code) is an error.
+try {
+    basics.private_method()
+    assert false, "expected private_method() to be inaccessible from outside the class"
+} catch as e {
+    assert e == "Cannot access private member 'private_method' of class 'VisibilityBasics' from outside its class hierarchy"
+}
+try {
+    basics.protected_method()
+    assert false, "expected protected_method() to be inaccessible from outside the class"
+} catch as e {
+    assert e == "Cannot access protected member 'protected_method' of class 'VisibilityBasics' from outside its class hierarchy"
+}
 
 assert VisibilityStaticOrders.sum(4, 5) == 9
-assert VisibilityStaticOrders.product(4, 5) == 20
-assert VisibilityStaticOrders.diff(4, 5) == -1
-assert VisibilityStaticOrders.join("a", "b") == "a:b"
+try {
+    VisibilityStaticOrders.product(4, 5)
+    assert false, "expected product() to be inaccessible from outside the class"
+} catch as e {
+    assert e == "Cannot access private member 'product' of class 'VisibilityStaticOrders' from outside its class hierarchy"
+}
+try {
+    VisibilityStaticOrders.diff(4, 5)
+    assert false, "expected diff() to be inaccessible from outside the class"
+} catch as e {
+    assert e == "Cannot access protected member 'diff' of class 'VisibilityStaticOrders' from outside its class hierarchy"
+}
+try {
+    VisibilityStaticOrders.join("a", "b")
+    assert false, "expected join() to be inaccessible from outside the class"
+} catch as e {
+    assert e == "Cannot access protected member 'join' of class 'VisibilityStaticOrders' from outside its class hierarchy"
+}
 
 var internal = VisibilityInternalCalls(4)
 assert internal.calculate() == 20

--- a/tests/lang/encapsulation.rn
+++ b/tests/lang/encapsulation.rn
@@ -1,0 +1,101 @@
+# Encapsulation (#212): public/private/protected are enforced at runtime.
+# public   -> accessible from anywhere.
+# protected -> accessible from the declaring class and its subclasses.
+# private  -> accessible only from the exact declaring class (not even subclasses).
+
+# Private access is scoped to the class, not the instance: one instance's
+# method can reach another instance's private members of the same class.
+class Wallet {
+    fun __constructor__(balance) {
+        this.balance = balance
+    }
+
+    private fun peek() -> this.balance
+
+    public fun richer_than(other) -> this.peek() > other.peek()
+}
+
+var a = Wallet(100)
+var b = Wallet(50)
+assert a.richer_than(b) == true
+assert b.richer_than(a) == false
+
+# Nested blocks (if/while/for) inside a method still resolve the correct
+# owning class for private/protected access checks.
+class Counter {
+    fun __constructor__(n) {
+        this.n = n
+    }
+
+    private fun tick() -> 1
+
+    public fun count_to_zero() {
+        var total = 0
+        while this.n > 0 {
+            if true {
+                total = total + this.tick()
+            }
+            this.n = this.n - 1
+        }
+        return total
+    }
+}
+
+assert Counter(5).count_to_zero() == 5
+
+# A closure defined inside a method keeps that method's class context, so it
+# can still call private/protected members when invoked later.
+class Repeater {
+    fun __constructor__(value) {
+        this.value = value
+    }
+
+    private fun doubled() -> this.value * 2
+
+    public fun make_closure() {
+        fun inner() -> this.doubled()
+        return inner
+    }
+}
+
+var repeater = Repeater(21)
+var closure = repeater.make_closure()
+assert closure() == 42
+
+# An unrelated class (not a subclass) cannot reach another class's
+# private/protected members, even from inside its own methods.
+class Vault {
+    private fun secret() -> "vault-secret"
+    protected fun guarded() -> "vault-guarded"
+}
+
+class Outsider {
+    public fun try_secret(vault) -> vault.secret()
+    public fun try_guarded(vault) -> vault.guarded()
+}
+
+var vault = Vault()
+var outsider = Outsider()
+try {
+    outsider.try_secret(vault)
+    assert false, "expected private member to be inaccessible from an unrelated class"
+} catch as e {
+    assert e == "Cannot access private member 'secret' of class 'Vault' from outside its class hierarchy"
+}
+try {
+    outsider.try_guarded(vault)
+    assert false, "expected protected member to be inaccessible from an unrelated class"
+} catch as e {
+    assert e == "Cannot access protected member 'guarded' of class 'Vault' from outside its class hierarchy"
+}
+
+# A subclass CAN reach an inherited protected member through its own method.
+class Base {
+    protected fun helper() -> "base-helper"
+}
+
+class Derived(Base) {
+    public fun use_helper() -> this.helper()
+}
+
+assert Derived().use_helper() == "base-helper"

--- a/tests/lang/encapsulation.rn.json
+++ b/tests/lang/encapsulation.rn.json
@@ -1,0 +1,1 @@
+{"code": 0, "stdout": "", "stderr": ""}

--- a/tests/lang/inheritance_access_modifiers.rn
+++ b/tests/lang/inheritance_access_modifiers.rn
@@ -15,8 +15,21 @@ class ModChild(ModParent) {}
 var mod_child = ModChild(10)
 assert mod_child.implicit_method() == 10
 assert mod_child.public_method() == 11
-assert mod_child.private_method() == 12
-assert mod_child.protected_method() == 13
+
+# private/protected are enforced: outside the class hierarchy (here, top-level
+# script code) they raise a RuntimeError instead of returning a value.
+try {
+    mod_child.private_method()
+    assert false, "expected private_method() to be inaccessible from outside the class"
+} catch as e {
+    assert e == "Cannot access private member 'private_method' of class 'ModParent' from outside its class hierarchy"
+}
+try {
+    mod_child.protected_method()
+    assert false, "expected protected_method() to be inaccessible from outside the class"
+} catch as e {
+    assert e == "Cannot access protected member 'protected_method' of class 'ModParent' from outside its class hierarchy"
+}
 
 # Overriding across differing modifiers: child modifier need not match parent's
 class OverrideParent {
@@ -32,11 +45,23 @@ class OverrideChild(OverrideParent) {
 }
 
 var override_child = OverrideChild()
-assert override_child.greet() == "private-child"
-assert override_child.secret() == "protected-child"
 assert override_child.guarded() == "public-child"
+try {
+    override_child.greet()
+    assert false, "expected greet() to be inaccessible from outside the class"
+} catch as e {
+    assert e == "Cannot access private member 'greet' of class 'OverrideChild' from outside its class hierarchy"
+}
+try {
+    override_child.secret()
+    assert false, "expected secret() to be inaccessible from outside the class"
+} catch as e {
+    assert e == "Cannot access protected member 'secret' of class 'OverrideChild' from outside its class hierarchy"
+}
 
-# super() calls into private/protected parent methods regardless of the caller's own modifier
+# super() can reach a protected/public parent method from a subclass, but a
+# private parent method stays off-limits even via super() -- private members
+# are not inherited, matching standard OOP semantics.
 class SuperParent {
     private fun private_value() -> 100
     protected fun protected_value() -> 200
@@ -44,10 +69,17 @@ class SuperParent {
 }
 
 class SuperChild(SuperParent) {
-    public fun combined() -> super().private_value() + super().protected_value() + super().public_value()
+    public fun combined() -> super().protected_value() + super().public_value()
+    public fun try_private() -> super().private_value()
 }
 
-assert SuperChild().combined() == 600
+assert SuperChild().combined() == 500
+try {
+    SuperChild().try_private()
+    assert false, "expected super().private_value() to be inaccessible from a subclass"
+} catch as e {
+    assert e == "Cannot access private member 'private_value' of class 'SuperParent' from outside its class hierarchy"
+}
 
 # Static methods with every modifier-order combination, inherited without redefinition
 class StaticModParent {
@@ -60,9 +92,24 @@ class StaticModParent {
 class StaticModChild(StaticModParent) {}
 
 assert StaticModChild.add(2, 3) == 5
-assert StaticModChild.mul(2, 3) == 6
-assert StaticModChild.sub(5, 2) == 3
-assert StaticModChild.cat("a", "b") == "a:b"
+try {
+    StaticModChild.mul(2, 3)
+    assert false, "expected mul() to be inaccessible from outside the class"
+} catch as e {
+    assert e == "Cannot access private member 'mul' of class 'StaticModParent' from outside its class hierarchy"
+}
+try {
+    StaticModChild.sub(5, 2)
+    assert false, "expected sub() to be inaccessible from outside the class"
+} catch as e {
+    assert e == "Cannot access protected member 'sub' of class 'StaticModParent' from outside its class hierarchy"
+}
+try {
+    StaticModChild.cat("a", "b")
+    assert false, "expected cat() to be inaccessible from outside the class"
+} catch as e {
+    assert e == "Cannot access protected member 'cat' of class 'StaticModParent' from outside its class hierarchy"
+}
 
 # Overriding a static modified method in a child class
 class StaticOverrideParent {
@@ -73,16 +120,21 @@ class StaticOverrideChild(StaticOverrideParent) {
     public static fun label() -> "child"
 }
 
-assert StaticOverrideParent.label() == "parent"
 assert StaticOverrideChild.label() == "child"
+try {
+    StaticOverrideParent.label()
+    assert false, "expected label() to be inaccessible from outside the class"
+} catch as e {
+    assert e == "Cannot access private member 'label' of class 'StaticOverrideParent' from outside its class hierarchy"
+}
 
-# Multi-level inheritance chaining super() through mixed modifiers at each level
+# Multi-level inheritance chaining super() through protected methods at each level
 class ModGrand {
     protected fun stage() -> 1
 }
 
 class ModMid(ModGrand) {
-    private fun stage() -> super().stage() + 1
+    protected fun stage() -> super().stage() + 1
 }
 
 class ModLeaf(ModMid) {
@@ -91,17 +143,22 @@ class ModLeaf(ModMid) {
 
 assert ModLeaf().stage() == 3
 
-# Multiple inheritance (diamond) where same-named methods carry different modifiers
+# Multiple inheritance (diamond): cooperative super() chaining through a
+# diamond visits sibling mixins (e.g. ModLeft's super() can reach ModRight)
+# purely because of their shared participation in ModHybrid's MRO, not because
+# either is an ancestor of the other -- so this chain uses public methods
+# rather than asserting a specific answer to the ambiguous question of
+# whether protected access should be shared between cooperating siblings.
 class ModBase {
     public fun tag() -> "B"
 }
 
 class ModLeft(ModBase) {
-    private fun tag() -> super().tag() + "L"
+    public fun tag() -> super().tag() + "L"
 }
 
 class ModRight(ModBase) {
-    protected fun tag() -> super().tag() + "R"
+    public fun tag() -> super().tag() + "R"
 }
 
 class ModHybrid(ModLeft, ModRight) {
@@ -116,7 +173,7 @@ class ModCtorParent {
         this.value = value
     }
 
-    private fun doubled() -> this.value * 2
+    protected fun doubled() -> this.value * 2
     protected fun tripled() -> this.value * 3
 }
 


### PR DESCRIPTION
## Summary

Implements the two remaining checklist items from #49 (REP-2: Object Oriented System Enhancement Proposal) — **encapsulation** and **abstraction**. Together with the inheritance work from #219, this closes out #49.

Closes #212, #210, #211.

## What changed

### Encapsulation (#212)

`public` / `private` / `protected` were previously parsed but silently discarded — a "private" method was fully callable from anywhere. They are now enforced at runtime:

- **`private`**: accessible only from code executing inside the exact declaring class (not even subclasses, not even via `super()`) — matches standard Java/C++ semantics.
- **`protected`**: accessible anywhere in the ancestor/descendant chain, in **both directions**:
  - a subclass reaching an inherited protected member, and
  - base-class code that virtually dispatches into a subclass's protected override (the Template Method pattern — e.g. a base class's public method calling `this.save(item)` where `save` is `protected` and overridden by the subclass).
- **`public`** (the default): unchanged, accessible from anywhere.

```radon
class Account {
    private fun pin() -> 1234
    protected fun balance() -> 100
}

class Savings(Account) {
    public fun show_balance() -> this.balance()  # OK -- protected, inherited
}

Savings().show_balance()   # 100
Savings().pin()             # RuntimeError: Cannot access private member 'pin' ...
```

Implementation: a new `Interpreter._check_member_access` (core/interpreter.py), wired into `visit_AttrAccessNode`, checks the resolved method's `access_modifier`/`owner_class` (new fields on `Function`/`BaseFunction`, threaded from a new `FuncDefNode.access_modifier` field set by the parser) against the class of the code that's currently executing.

That "currently executing class" is resolved via a `__class__` entry set on each call's symbol table (`Function.execute`), not via `Context.parent` — a `Function`'s `.context` gets rebound to the call site every time it crosses a call or attribute-access boundary (see `call_value` / `visit_AttrAccessNode`), which would silently break the check for closures returned across those boundaries. `SymbolTable` is stable and lexically scoped, so it reliably threads through nested blocks and closures instead.

Field-level access control (e.g. `this.x` on instance fields) and the `ClassOrInstance / "name"` operator-overload access path (`BaseClass.dived_by`) are out of scope — only methods carry modifiers today, matching the existing parser support, and `dived_by` is an obscure, untested escape hatch.

### Abstraction (#210, #211)

New `abstract` keyword:

```radon
abstract class Shape {
    fun area()              # no body -- abstract method
    fun describe() -> "a shape with area " + str(this.area())
}

class Circle(Shape) {
    fun __constructor__(r) { this.r = r }
    fun area() -> this.r * this.r * 3
}

Circle(2).describe()   # "a shape with area 12"
Shape()                 # RuntimeError: Cannot instantiate abstract class 'Shape'

class Incomplete(Shape) {}   # RuntimeError at class-definition time:
                              # Class 'Incomplete' must implement abstract method(s): area
```

- `abstract class Foo { ... }` cannot be instantiated directly (checked in `BaseClass.execute`).
- A method with no body (`fun bar(x)` followed by neither `{ }` nor `->`) declares it abstract. This is only valid directly inside a class body (`self.in_class`), and the parser un-consumes any skipped newline in that case so `statements()` still sees the statement separator between it and the next method.
- A concrete (non-abstract) class must implement every abstract method it inherits from anywhere in its MRO — checked once at class-definition time (`visit_ClassNode`), not deferred to instantiation, so the error surfaces as early as possible. Multi-level abstract chains work (an abstract subclass doesn't need to implement its parent's abstract methods; only the first concrete class in the chain does).
- Defense in depth: `Function.execute` also raises if a body-less method is somehow invoked directly.

## Test plan

- [x] `python test.py run tests` — full suite passes, including the pre-existing `inheritance.rn` from #219
- [x] `ruff format --check .` / `ruff check .` — clean
- [x] `mypy . --strict` — clean
- [x] Updated `tests/lang/access_modifiers.rn` and `tests/lang/inheritance_access_modifiers.rn` — these previously called private/protected members from top-level script code, which only worked because nothing was enforced; now they assert the correct `RuntimeError` is raised instead
- [x] New `tests/lang/encapsulation.rn` — cross-instance private access within the same class, nested blocks/closures preserving class context, unrelated external classes being denied, subclass access to inherited protected members
- [x] New `tests/lang/abstract_classes.rn` — direct instantiation rejected, incomplete override rejected, multi-level abstract chains, abstract classes mixing concrete/static/modified methods with abstract declarations

## Notable design call

Diamond multiple inheritance with cooperative `super()` chaining raises a genuinely ambiguous question with no clean universal answer: should a sibling mixin's `protected` member be reachable from another sibling purely because they're both mixed into the same instance (not because either is an ancestor of the other)? Real languages mostly sidestep this (Java has no multiple inheritance of implementation; C++ doesn't have `super()`). Rather than guessing at semantics here, the diamond-inheritance test in `inheritance_access_modifiers.rn` uses `public` methods for that specific chain, leaving the question open rather than asserting an answer.