### PR TITLE
Exempt trusted stdlib/builtin code from security prompts

### DIFF
--- a/core/builtin_classes/file_object.py
+++ b/core/builtin_classes/file_object.py
@@ -17,7 +17,7 @@ class FileObject(BuiltInObject):
     @operator("__constructor__")
     @check([String, String], [None, String("r")])
     def constructor(self, path: String, mode: String) -> RTResult[Value]:
-        security.security_prompt("disk_access")
+        security.security_prompt("disk_access", path.pos_start)
 
         allowed_modes = [None, "r", "w", "a", "r+", "w+", "a+"]  # Allowed modes for opening files
         res = RTResult[Value]()
@@ -34,7 +34,7 @@ class FileObject(BuiltInObject):
     @args(["count"], [Number(-1)])
     @method
     def read(self, ctx: Context) -> RTResult[Value]:
-        security.security_prompt("disk_access")
+        security.security_prompt("disk_access", ctx.parent_entry_pos)
 
         res = RTResult[Value]()
         count = ctx.symbol_table.get("count")
@@ -56,7 +56,7 @@ class FileObject(BuiltInObject):
     @args([])
     @method
     def readline(self, ctx: Context) -> RTResult[Value]:
-        security.security_prompt("disk_access")
+        security.security_prompt("disk_access", ctx.parent_entry_pos)
 
         res = RTResult[Value]()
         try:
@@ -69,7 +69,7 @@ class FileObject(BuiltInObject):
     @args([])
     @method
     def readlines(self, ctx: Context) -> RTResult[Value]:
-        security.security_prompt("disk_access")
+        security.security_prompt("disk_access", ctx.parent_entry_pos)
 
         res = RTResult[Value]()
         try:
@@ -82,7 +82,7 @@ class FileObject(BuiltInObject):
     @args(["data"])
     @method
     def write(self, ctx: Context) -> RTResult[Value]:
-        security.security_prompt("disk_access")
+        security.security_prompt("disk_access", ctx.parent_entry_pos)
 
         res = RTResult[Value]()
         data = ctx.symbol_table.get("data")
@@ -101,7 +101,7 @@ class FileObject(BuiltInObject):
     @args([])
     @method
     def close(self, _ctx: Context) -> RTResult[Value]:
-        security.security_prompt("disk_access")
+        security.security_prompt("disk_access", _ctx.parent_entry_pos)
 
         res = RTResult[Value]()
         self.file.close()
@@ -110,7 +110,7 @@ class FileObject(BuiltInObject):
     @args([])
     @method
     def is_closed(self, _ctx: Context) -> RTResult[Value]:
-        security.security_prompt("disk_access")
+        security.security_prompt("disk_access", _ctx.parent_entry_pos)
 
         res = RTResult[Value]()
         return res.success(Boolean(self.file.closed))

--- a/core/builtin_classes/requests_object.py
+++ b/core/builtin_classes/requests_object.py
@@ -21,7 +21,7 @@ class RequestsObject(BuiltInObject):
     @args(["url", "headers"], [None, HashMap({})])
     @method
     def get(self, ctx: Context) -> RTResult[Value]:
-        security.security_prompt("network_access")
+        security.security_prompt("network_access", ctx.parent_entry_pos)
 
         res = RTResult[Value]()
         url = ctx.symbol_table.get("url")
@@ -43,7 +43,7 @@ class RequestsObject(BuiltInObject):
     @args(["url", "data", "headers"], [None, HashMap({}), HashMap({})])
     @method
     def post(self, ctx: Context) -> RTResult[Value]:
-        security.security_prompt("network_access")
+        security.security_prompt("network_access", ctx.parent_entry_pos)
 
         res = RTResult[Value]()
         url = ctx.symbol_table.get("url")
@@ -73,7 +73,7 @@ class RequestsObject(BuiltInObject):
     @args(["url", "data", "headers"], [None, HashMap({}), HashMap({})])
     @method
     def put(self, ctx: Context) -> RTResult[Value]:
-        security.security_prompt("network_access")
+        security.security_prompt("network_access", ctx.parent_entry_pos)
 
         res = RTResult[Value]()
         url = ctx.symbol_table.get("url")
@@ -102,7 +102,7 @@ class RequestsObject(BuiltInObject):
     @args(["url", "headers"], [None, HashMap({})])
     @method
     def delete(self, ctx: Context) -> RTResult[Value]:
-        security.security_prompt("network_access")
+        security.security_prompt("network_access", ctx.parent_entry_pos)
 
         res = RTResult[Value]()
         url = ctx.symbol_table.get("url")
@@ -124,7 +124,7 @@ class RequestsObject(BuiltInObject):
     @args(["url", "data", "headers"], [None, HashMap({}), HashMap({})])
     @method
     def patch(self, ctx: Context) -> RTResult[Value]:
-        security.security_prompt("network_access")
+        security.security_prompt("network_access", ctx.parent_entry_pos)
 
         res = RTResult[Value]()
         url = ctx.symbol_table.get("url")

--- a/core/builtin_funcs.py
+++ b/core/builtin_funcs.py
@@ -282,7 +282,7 @@ class BuiltInFunction(BaseFunction):
 
     @args(["code", "ns"])
     def execute_pyapi(self, exec_ctx: Context) -> RTResult[Value]:
-        security.security_prompt("pyapi_access")
+        security.security_prompt("pyapi_access", exec_ctx.parent_entry_pos)
 
         res = RTResult[Value]()
 

--- a/core/security.py
+++ b/core/security.py
@@ -20,7 +20,6 @@ allowed: dict[str, bool] = {}
 _STDLIB_DIR = (BASE_DIR / "stdlib").resolve()
 
 
-# !!! Only used for tests !!!
 def allow_all_permissions() -> None:
     allowed["pyapi_access"] = True
     allowed["disk_access"] = True

--- a/core/security.py
+++ b/core/security.py
@@ -1,6 +1,8 @@
-from typing import Literal
+from pathlib import Path
+from typing import Literal, Optional
 
 from core.colortools import Log
+from core.tokens import BASE_DIR, Position
 
 # Define all types of security prompts
 SecurityPromptType = Literal["pyapi_access", "disk_access", "network_access"]
@@ -13,6 +15,10 @@ type_messages: dict[str, str] = {
 # List of allowed actions (used during code execution)
 allowed: dict[str, bool] = {}
 
+# The interpreter's own stdlib/ directory -- code that lives here is part of
+# the interpreter's trusted internals, not user-supplied.
+_STDLIB_DIR = (BASE_DIR / "stdlib").resolve()
+
 
 # !!! Only used for tests !!!
 def allow_all_permissions() -> None:
@@ -21,9 +27,30 @@ def allow_all_permissions() -> None:
     allowed["network_access"] = True
 
 
-def security_prompt(type: SecurityPromptType) -> None:
+def is_trusted_source(fn: Optional[str]) -> bool:
+    """Whether `fn` is a source file the interpreter ships itself (stdlib/), as
+    opposed to a user-supplied script or module.
+
+    This is a location check, not a content check -- there is no in-language
+    keyword or function a script can write to grant itself this trust. Being
+    physically located under the interpreter's own stdlib/ directory is the
+    only thing that counts, and a script can't place a file there without
+    already having write access to the interpreter's own installation.
+    """
+    if not fn:
+        return False
+    try:
+        return Path(fn).resolve().is_relative_to(_STDLIB_DIR)
+    except (OSError, ValueError):
+        return False
+
+
+def security_prompt(type: SecurityPromptType, pos: Optional[Position] = None) -> None:
     # If action already allowed, continue
     if type in allowed:
+        return
+    # Trusted internal call sites (the interpreter's own stdlib) never prompt.
+    if pos is not None and is_trusted_source(pos.fn):
         return
     # Log the message and get a y/n prompt by user
     print(f"{Log.deep_warning(f'[{type.upper()}]')} {Log.deep_info(type_messages[type], True)}. Continue execution?")


### PR DESCRIPTION
## Summary

Closes #225.

Security prompts (`pyapi_access`, `disk_access`, `network_access`) are meant to warn a user when *their own script* is about to do something sensitive. But several stdlib convenience functions trigger them as an implementation detail the user never asked for or wrote themselves -- e.g. `io.Input.get_password()` triggers `[PYAPI_ACCESS] This program is attempting to use the Python API` even though the script never calls `pyapi()`; it's `stdlib/io.rn` doing that internally to reach Python's `getpass` module.

## How it works

`security_prompt()` now takes an optional call-site `Position` and skips prompting entirely when that position resolves to a file under the interpreter's own `stdlib/` directory (`is_trusted_source()`, new in `core/security.py`).

This is a **location check, not a content check** -- there's no in-language keyword, function, or magic comment a script could write to grant itself the same trust, since Radon source text isn't distinguishable from itself by content. The only thing that counts is where the code physically lives on disk, and a script can't place a file under the interpreter's own `stdlib/` without already having write access to the interpreter's own installation -- at which point someone could just edit `core/security.py` directly, so this isn't a new attack surface.

Applies uniformly to all three prompt types, not just `pyapi_access`: `File` (`disk_access`, 7 call sites) and `Requests` (`network_access`, 5 call sites) get the same treatment, even though no stdlib module currently uses them internally -- it's the same class of problem in principle.

## Commits (grouped by what they do)

1. **Core mechanism** (`core/security.py`) -- `is_trusted_source()` + `security_prompt()`'s new optional `pos` parameter. No call sites wired up yet; fully backward compatible (existing single-argument calls still work, `pos` defaults to `None`, which never exempts).
2. **`pyapi_access` wiring** (`core/builtin_funcs.py`) -- fixes the concrete repro from #225.
3. **`disk_access`/`network_access` wiring** (`File`, `Requests`) -- generalizes the same fix to the other two prompt types.

## Test plan

- [x] Full test suite (`python test.py run tests`), `ruff format`/`ruff check`, `mypy --strict` all clean
- [x] `is_trusted_source()` correctly distinguishes a `stdlib/` file from a user script (unit-checked directly)
- [x] `import os; os.getcwd()` (uses `pyapi()` internally) now runs with **zero prompt** -- verified by piping `"n"` and it still succeeding, proving the prompt was actually skipped rather than silently auto-approved
- [x] A user script calling `pyapi(...)` directly **still prompts** and still respects deny (piping `"n"` → `Permission denied by user.`, exit 1)
- [x] Same for `File(...)` (`disk_access`): still prompts for direct user usage, still respects deny, and approving once still covers subsequent calls in the same run (existing `allowed` cache preserved)

## Bugs caught during implementation (fixed before landing, not present in this diff)

- `File.close()`/`is_closed()` take a parameter named `_ctx`, not `ctx` -- a naive find-and-replace across all `security_prompt("disk_access")` call sites would have produced a `NameError` at runtime for those two methods specifically. Caught by testing each call site's actual parameter name individually rather than trusting a blanket substitution.

## Known follow-up (not in this PR)

`stdlib/os.rn` wraps every filesystem operation (`mkdir`, `rmdir`, `remove`, `chmod`, `unlink`, ...) through `pyapi()` with no gate of its own -- today the generic `pyapi_access` prompt is the only thing standing in front of those. This PR's exemption means `os.rn`'s real filesystem mutations become entirely unprompted as a side effect. Tracked separately in #224, since it needs its own design decision (blanket vs. selective gating) and shouldn't block this UX fix.